### PR TITLE
maintain(test): Email handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-.phpunit.result.cache
-composer.lock
-/vendor
+/composer.lock
+/phpunit.xml
+/vendor/
+/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
 	"require-dev" : {
 		"phpstan/phpstan": "^0.12",
 		"symfony/phpunit-bridge": "^5.1",
-		"squizlabs/php_codesniffer": "^3.4"
+		"squizlabs/php_codesniffer": "^3.4",
+		"symfony/yaml": "^4.4"
 	},
 	"autoload" : {
 		"psr-4" : {

--- a/src/FormConfig/EmailConfig.php
+++ b/src/FormConfig/EmailConfig.php
@@ -22,8 +22,8 @@ class EmailConfig extends AbstractConfig
         $this->endpoint = $submission->getEndpoint();
         $message = \json_decode($submission->getMessage(), true);
 
-        $this->from = $message['from'];
-        $this->subject = $message['subject'];
+        $this->from = $message['from'] ?? 'noreply@elasticms.eu';
+        $this->subject = $message['subject'] ?? 'Email submission';
 
         if (!empty($message['body'])) {
             $this->body = $this->sanitiseQuotes($message['body']) ?? '';

--- a/tests/Functional/AbstractFunctionalTest.php
+++ b/tests/Functional/AbstractFunctionalTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\SubmissionBundle\Tests\Functional;
+
+use EMS\SubmissionBundle\Tests\Functional\App\Kernel;
+use PHPStan\Testing\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\Forms;
+
+abstract class AbstractFunctionalTest extends TestCase
+{
+    /** @var ContainerInterface */
+    protected $container;
+    /** @var FormFactoryInterface */
+    protected $formFactory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $kernel = new Kernel('test', true);
+        $kernel->boot();
+
+        $this->container = $kernel->getContainer();
+        $this->formFactory = Forms::createFormFactoryBuilder()->getFormFactory();
+    }
+}

--- a/tests/Functional/App/Kernel.php
+++ b/tests/Functional/App/Kernel.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\SubmissionBundle\Tests\Functional\App;
+
+use EMS\SubmissionBundle\EMSSubmissionBundle;
+use Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+use Twig\Loader\ArrayLoader;
+
+final class Kernel extends BaseKernel
+{
+    public function getCacheDir()
+    {
+        return __DIR__ . '/../../tmp/cache/' .$this->environment;
+    }
+
+    public function getLogDir()
+    {
+        return __DIR__ . '/../../tmp/log';
+    }
+
+    public function registerBundles(): array
+    {
+        return [
+            new EMSSubmissionBundle(),
+            new SwiftmailerBundle(),
+        ];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+        $loader->load(__DIR__ . '/config/config.yml');
+    }
+
+    protected function build(ContainerBuilder $container): void
+    {
+        $definitionTwig = new Definition(\Twig_Environment::class, [
+            new Definition(ArrayLoader::class, [[]]),
+            ['debug' => true, 'cache' => false]
+        ]);
+
+        $container->setDefinition('twig', $definitionTwig);
+    }
+}

--- a/tests/Functional/App/config/config.yml
+++ b/tests/Functional/App/config/config.yml
@@ -1,0 +1,14 @@
+ems_submission:
+  default_timeout: '10'
+  connections:
+    - { connection: "service-now-instance-a", user: "instance-a-username", password: "instance-a-password"}
+
+swiftmailer:
+  disable_delivery: true
+
+services:
+  # alias the service so we can access it in the tests
+  functional_test.emss.emailhandler:
+    alias: emss.emailhandler
+    public: true
+

--- a/tests/Functional/Handler/EmailHandlerTest.php
+++ b/tests/Functional/Handler/EmailHandlerTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\SubmissionBundle\Tests\Functional\Handler;
+
+use EMS\FormBundle\FormConfig\FormConfig;
+use EMS\FormBundle\FormConfig\SubmissionConfig;
+use EMS\FormBundle\Submit\AbstractResponse;
+use EMS\SubmissionBundle\Handler\EmailHandler;
+use EMS\SubmissionBundle\Tests\Functional\AbstractFunctionalTest;
+use Swift_Events_SendEvent;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
+final class EmailHandlerTest  extends AbstractFunctionalTest
+{
+    /** @var EmailHandler */
+    protected $emailHandler;
+    /** @var \Swift_Mailer */
+    protected $mailer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->emailHandler = $this->container->get('functional_test.emss.emailhandler');
+        $this->mailer = $this->container->get('mailer');
+    }
+
+    public function testSubmitFormData(): void
+    {
+        $data = ['name' => 'David', 'email' => 'user1@test.test',];
+        $form = $this->formFactory->createBuilder(FormType::class, $data, [])
+            ->add('name', TextType::class)
+            ->add('email', EmailType::class)
+            ->getForm();
+
+        $endpoint = '{{ data.email }}';
+        $message = json_encode([
+            'from' => 'noreply@test.test',
+            'subject' => 'Test submission',
+            'body' => 'Hi my name is {{ data.name }}'
+        ]);
+
+        $handle = $this->handle($form, $endpoint, $message, function (Swift_Events_SendEvent $evt) {
+            $this->assertEquals(['user1@test.test'], array_keys($evt->getMessage()->getTo()));
+            $this->assertEquals(['noreply@test.test'], array_keys($evt->getMessage()->getFrom()));
+            $this->assertEquals('Test submission', $evt->getMessage()->getSubject());
+            $this->assertEquals('Hi my name is David', $evt->getMessage()->getBody());
+        });
+
+        $this->assertEquals('{"status":"success","data":"Submission send by mail."}', $handle->getResponse());
+    }
+
+    public function testSubmitMultipleFiles(): void
+    {
+        $data = ['name' => 'David', 'files' => [
+            new UploadedFile(__DIR__ . '/../../files/attachment.txt', 'attachment.txt', 'text/plain'),
+            new UploadedFile(__DIR__ . '/../../files/attachment2.txt', 'attachment2.txt', 'text/plain'),
+        ]];
+        $form = $this->formFactory->createBuilder(FormType::class, $data, [])
+            ->add('name', TextType::class)
+            ->add('files', FileType::class, ['multiple' => true])
+            ->getForm();
+
+        $endpoint = 'test@example.com';
+        $message = json_encode([
+            'from' => 'noreply@test.test',
+            'subject' => 'Test multiple file upload',
+            'body' => "{{ data.files|map(v => v.getClientOriginalName())|join(' | ') }}",
+            'attachments' => [
+                'file1' => [
+                    'pathname' => '{{ data.files.0.getPathname()|json_encode }}',
+                    'originalName' => '{{ data.files.0.getClientOriginalName() }}',
+                    'mimeType' => '{{ data.files.0.getClientMimeType() }}'
+                ],
+                'file2' => [
+                    'pathname' => '{{ data.files.1.getPathname()|json_encode }}',
+                    'originalName' => '{{ data.files.1.getClientOriginalName() }}',
+                    'mimeType' => '{{ data.files.1.getClientMimeType() }}'
+                ]
+            ]
+        ]);
+
+        $handle = $this->handle($form, $endpoint, $message, function (Swift_Events_SendEvent $evt) {
+            $this->assertEquals('attachment.txt | attachment2.txt', $evt->getMessage()->getBody());
+
+            /** @var \Swift_Attachment[] $children */
+            $children = $evt->getMessage()->getChildren();
+
+            $this->assertEquals('attachment.txt', $children[0]->getFilename());
+            $this->assertEquals('Text example attachment', $children[0]->getBody());
+
+            $this->assertEquals('attachment2.txt', $children[1]->getFilename());
+            $this->assertEquals('Text example attachment2', $children[1]->getBody());
+        });
+
+        $this->assertEquals('{"status":"success","data":"Submission send by mail."}', $handle->getResponse());
+    }
+
+    public function testEmptyEndpoint(): void
+    {
+        $form = $this->formFactory->createBuilder(FormType::class, [], [])->getForm();
+        $message = json_encode([
+            'from' => 'noreply@test.test',
+            'subject' => 'Test submission',
+            'body' => 'example'
+        ]);
+        $handle = $this->handle($form, '', $message);
+
+        $this->assertEquals(
+            '{"status":"error","data":"Submission failed, contact your admin. Address in mailbox given [] does not comply with RFC 2822, 3.6.2."}',
+            $handle->getResponse()
+        );
+    }
+
+    public function testInvalidMessage(): void
+    {
+        $form = $this->formFactory->createBuilder(FormType::class, [], [])->getForm();
+
+        $handle = $this->handle($form, 'user@example.com', '', function (Swift_Events_SendEvent $evt) {
+            $this->assertEquals(['user@example.com'], array_keys($evt->getMessage()->getTo()));
+            $this->assertEquals(['noreply@elasticms.eu'], array_keys($evt->getMessage()->getFrom()));
+            $this->assertEquals('Email submission', $evt->getMessage()->getSubject());
+            $this->assertEquals('', $evt->getMessage()->getBody());
+        });
+
+        $this->assertEquals(
+            '{"status":"success","data":"Submission send by mail."}',
+            $handle->getResponse()
+        );
+    }
+
+    public function testFailedRecipients(): void
+    {
+        $form = $this->formFactory->createBuilder(FormType::class, [], [])->getForm();
+
+        $this->mailer->registerPlugin(new class implements \Swift_Events_SendListener {
+            public function beforeSendPerformed(Swift_Events_SendEvent $evt)
+            {
+                throw new \Swift_RfcComplianceException('test');
+            }
+
+            public function sendPerformed(Swift_Events_SendEvent $evt)
+            {
+            }
+        });
+
+        $this->assertEquals(
+            '{"status":"error","data":"Submission failed. Conctact your admin."}',
+            $this->handle($form, 'user@example.com', '')->getResponse()
+        );
+    }
+
+    private function handle(FormInterface $form, string $endpoint, string $message, callable $emailAssert = null): AbstractResponse
+    {
+        $submission = new SubmissionConfig(EmailHandler::class, $endpoint, $message);
+        $formConfig = new FormConfig('1', 'nl', 'nl');
+
+        if ($emailAssert) {
+            $this->mailer->registerPlugin(new class($emailAssert) implements \Swift_Events_SendListener {
+                /** @var callable */
+                private $callback;
+
+                public function __construct(callable $callback)
+                {
+                    $this->callback = $callback;
+                }
+
+                public function beforeSendPerformed(Swift_Events_SendEvent $evt)
+                {
+                }
+                public function sendPerformed(Swift_Events_SendEvent $evt)
+                {
+                    $callback = $this->callback;
+                    $callback($evt);
+                }
+            });
+        }
+
+        return $this->emailHandler->handle($submission, $form, $formConfig);
+    }
+}

--- a/tests/files/attachment.txt
+++ b/tests/files/attachment.txt
@@ -1,0 +1,1 @@
+Text example attachment

--- a/tests/files/attachment2.txt
+++ b/tests/files/attachment2.txt
@@ -1,0 +1,1 @@
+Text example attachment2


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |yes|
|New feature?   |no|	
|BC breaks?     |no|	
|Deprecations?  |no|	
|Fixed tickets  |no|	

Message config form and subject now have a default value, because code expects string