### PR TITLE
feat: form submission route

### DIFF
--- a/src/Entity/FormSubmission.php
+++ b/src/Entity/FormSubmission.php
@@ -74,7 +74,7 @@ class FormSubmission
     /**
      * @var Collection<int, FormSubmissionFile>
      *
-     * @ORM\OneToMany(targetEntity="FormSubmissionFile", mappedBy="formSubbmission", cascade={"persist", "remove"})
+     * @ORM\OneToMany(targetEntity="FormSubmissionFile", mappedBy="formSubmission", cascade={"persist", "remove"})
      */
     protected $files;
 

--- a/src/EventSubscriber/FormSubmissionRequestSubscriber.php
+++ b/src/EventSubscriber/FormSubmissionRequestSubscriber.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\SubmissionBundle\EventSubscriber;
+
+use EMS\SubmissionBundle\Repository\FormSubmissionRepository;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class FormSubmissionRequestSubscriber implements EventSubscriberInterface
+{
+    /** @var FormSubmissionRepository */
+    private $formSubmissionRepository;
+
+    public function __construct(FormSubmissionRepository $formSubmissionRepository)
+    {
+        $this->formSubmissionRepository = $formSubmissionRepository;
+    }
+
+    public function onKernelController(ControllerEvent $event): void
+    {
+        $request = $event->getRequest();
+        $formSubmissionId = $request->get('formSubmissionId');
+
+        if (null === $formSubmissionId) {
+            return;
+        }
+
+        $formSubmission = $this->formSubmissionRepository->findById($formSubmissionId);
+
+        if (null === $formSubmission) {
+            throw new NotFoundHttpException(\sprintf('Form submission with id %s not found', $formSubmissionId));
+        }
+
+        $request->attributes->set('formSubmission', $formSubmission);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::CONTROLLER => 'onKernelController',
+        ];
+    }
+}

--- a/src/Repository/FormSubmissionRepository.php
+++ b/src/Repository/FormSubmissionRepository.php
@@ -7,9 +7,24 @@ namespace EMS\SubmissionBundle\Repository;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use EMS\SubmissionBundle\Dto\FormSubmissionsCountDto;
+use EMS\SubmissionBundle\Entity\FormSubmission;
 
 final class FormSubmissionRepository extends ServiceEntityRepository
 {
+    public function findById(string $id): ?FormSubmission
+    {
+        try {
+            $qb = $this->createQueryBuilder('fs');
+            $qb
+                ->andWhere($qb->expr()->eq('fs.id', ':id'))
+                ->setParameter('id', $id);
+
+            return $qb->getQuery()->getOneOrNullResult();
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+
     public function getCounts(string $name, string $period, ?string $instance): FormSubmissionsCountDto
     {
         $qb = $this->createCountQueryBuilder($name, $instance);

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -15,6 +15,10 @@
             <argument type="service" id="twig"/>
             <tag name="console.command" />
         </service>
+        <service id="emss.event_subscriber.form_submission_request" class="EMS\SubmissionBundle\EventSubscriber\FormSubmissionRequestSubscriber">
+            <argument type="service" id="emss.repository.form_submission"/>
+            <tag name="kernel.event_subscriber" />
+        </service>
         <service id="emss.repository.form_submission" class="EMS\SubmissionBundle\Repository\FormSubmissionRepository">
             <argument type="service" id="doctrine" />
             <argument type="string">EMS\SubmissionBundle\Entity\FormSubmission</argument>


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |no|
|New feature?   |yes|	
|BC breaks?     |no|	
|Deprecations?  |no|	
|Fixed tickets  |no|	

If we define a route attribute named formSubmissionId, the submissionBundle will add a a new attribute named: formSubmission. This way the clientHelperBundle stays in control of the routing system. 