### PR TITLE
fix: remove swift-mailer for sf mailer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -16,7 +16,6 @@ return $config
     ->setRules([
         '@Symfony' => true,
         'declare_strict_types' => true,
-        'final_class' => true,
         'native_function_invocation' => ['include' => ['@all']],
         'no_unused_imports' => true
     ])

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"elasticms/form-bundle" : "5.0.x-dev",
 		"symfony/framework-bundle": "^4.4",
 		"symfony/http-client": "^4.4",
-		"symfony/swiftmailer-bundle": "^3.4",
+		"symfony/mailer": "^4.4",
 		"symfony/twig-bundle": "^4.4",
 		"twig/twig" : "^2.14",
 		"league/flysystem-sftp": "^1.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,6 +16,7 @@
     <ini name="error_reporting" value="-1"/>
     <env name="SYMFONY_PHPUNIT_VERSION" value="9.5"/>
     <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[total]=0"/>
+    <env name="KERNEL_CLASS" value="EMS\SubmissionBundle\Tests\Functional\App\Kernel"/>
   </php>
 
   <testsuites>

--- a/src/EMSSubmissionBundle.php
+++ b/src/EMSSubmissionBundle.php
@@ -4,13 +4,8 @@ declare(strict_types=1);
 
 namespace EMS\SubmissionBundle;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 final class EMSSubmissionBundle extends Bundle
 {
-    public function build(ContainerBuilder $container): void
-    {
-        parent::build($container);
-    }
 }

--- a/src/Handler/EmailHandler.php
+++ b/src/Handler/EmailHandler.php
@@ -11,15 +11,15 @@ use EMS\FormBundle\Submission\HandleResponseInterface;
 use EMS\SubmissionBundle\Request\EmailRequest;
 use EMS\SubmissionBundle\Response\EmailHandleResponse;
 use EMS\SubmissionBundle\Twig\TwigRenderer;
+use Symfony\Component\Mailer\Mailer;
+use Symfony\Component\Mime\Email;
 
 final class EmailHandler extends AbstractHandler
 {
-    /** @var \Swift_Mailer */
-    private $mailer;
-    /** @var TwigRenderer */
-    private $twigRenderer;
+    private Mailer $mailer;
+    private TwigRenderer $twigRenderer;
 
-    public function __construct(\Swift_Mailer $mailer, TwigRenderer $twigRenderer)
+    public function __construct(Mailer $mailer, TwigRenderer $twigRenderer)
     {
         $this->mailer = $mailer;
         $this->twigRenderer = $twigRenderer;
@@ -32,21 +32,16 @@ final class EmailHandler extends AbstractHandler
             $message = $this->twigRenderer->renderMessageJSON($handleRequest);
 
             $emailRequest = new EmailRequest($endpoint, $message);
-            $message = (new \Swift_Message($emailRequest->getSubject()))
-                ->setFrom($emailRequest->getFrom())
-                ->setTo($emailRequest->getEndpoint())
-                ->setBody($emailRequest->getBody(), $emailRequest->getContentType());
 
-            foreach ($this->createAttachments($emailRequest) as $attachment) {
-                $message->attach($attachment);
-            }
+            $message = (new Email())
+                ->subject($emailRequest->getSubject())
+                ->from($emailRequest->getFrom())
+                ->to($emailRequest->getEndpoint())
+                ->html($emailRequest->getBody());
 
-            $failedRecipients = [];
-            $this->mailer->send($message, $failedRecipients);
+            $this->addAttachments($emailRequest, $message);
 
-            if ([] !== $failedRecipients) {
-                throw new \RuntimeException(\sprintf('Submission configured per mail and not send to %d recipients', \count($failedRecipients)));
-            }
+            $this->mailer->send($message);
         } catch (\Exception $exception) {
             return new FailedHandleResponse(\sprintf('Submission failed, contact your admin. %s', $exception->getMessage()));
         }
@@ -54,10 +49,7 @@ final class EmailHandler extends AbstractHandler
         return new EmailHandleResponse($message);
     }
 
-    /**
-     * @return \Traversable<\Swift_Attachment>
-     */
-    private function createAttachments(EmailRequest $emailRequest): \Traversable
+    private function addAttachments(EmailRequest $emailRequest, Email $message): void
     {
         foreach ($emailRequest->getAttachments() as $attachment) {
             $filename = $attachment['originalName'] ?? $attachment['filename'] ?? null;
@@ -69,15 +61,9 @@ final class EmailHandler extends AbstractHandler
 
             if (isset($attachment['base64'])) {
                 $data = \base64_decode($attachment['base64']);
-
-                yield new \Swift_Attachment($data, $filename, $mimeType);
-                continue;
-            }
-
-            if (isset($attachment['pathname'])) {
-                $swiftAttachment = \Swift_Attachment::fromPath($attachment['pathname'], $mimeType);
-                $swiftAttachment->setFilename($filename);
-                yield $swiftAttachment;
+                $message->attach($data, $filename, $mimeType);
+            } elseif (isset($attachment['pathname'])) {
+                $message->attachFromPath($attachment['pathname'], $filename, $mimeType);
             }
         }
     }

--- a/src/Repository/FormSubmissionRepository.php
+++ b/src/Repository/FormSubmissionRepository.php
@@ -14,7 +14,7 @@ use EMS\SubmissionBundle\Entity\FormSubmission;
 /**
  * @extends ServiceEntityRepository<FormSubmission>
  */
-final class FormSubmissionRepository extends ServiceEntityRepository
+class FormSubmissionRepository extends ServiceEntityRepository
 {
     public function __construct(Registry $registry)
     {

--- a/src/Request/DatabaseRequest.php
+++ b/src/Request/DatabaseRequest.php
@@ -37,7 +37,7 @@ final class DatabaseRequest
         $this->data = $record['data'];
         $this->files = $record['files'];
         $this->label = $record['label'] ?? '';
-        $formattedDate = \DateTime::createFromFormat(\DateTime::ATOM, $record['expire_date']);
+        $formattedDate = \DateTime::createFromFormat(\DateTimeInterface::ATOM, $record['expire_date']);
         $this->expireDate = false != $formattedDate ? $formattedDate : null;
     }
 

--- a/src/Request/EmailRequest.php
+++ b/src/Request/EmailRequest.php
@@ -26,7 +26,7 @@ final class EmailRequest
         $this->endpoint = $endpoint;
 
         if (!isset($message['from'])) {
-            throw new \Exception(\sprintf('From email address not defined.'));
+            throw new \Exception('From email address not defined.');
         }
 
         $this->from = $message['from'];

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -12,7 +12,6 @@
         <service id="emss.command.database_stats" class="EMS\SubmissionBundle\Command\DatabaseStatsCommand">
             <argument type="service" id="mailer"/>
             <argument type="service" id="emss.repository.form_submission"/>
-            <argument type="service" id="twig"/>
             <tag name="console.command" />
         </service>
         <service id="emss.event_subscriber.form_submission_request" class="EMS\SubmissionBundle\EventSubscriber\FormSubmissionRequestSubscriber">

--- a/src/Resources/views/mail/stats.html.twig
+++ b/src/Resources/views/mail/stats.html.twig
@@ -1,7 +1,6 @@
-{% block body %}
 {# @var count \EMS\SubmissionBundle\Dto\FormSubmissionsCountDto #}
 <!doctype html>
-<html>
+<html lang="en">
     <head>
         <meta name="viewport" content="width=device-width" />
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
@@ -28,4 +27,3 @@
         <p><i>{{ from }}</i></p>
     </body>
 </html>
-{% endblock %}

--- a/src/Response/EmailHandleResponse.php
+++ b/src/Response/EmailHandleResponse.php
@@ -5,20 +5,20 @@ declare(strict_types=1);
 namespace EMS\SubmissionBundle\Response;
 
 use EMS\FormBundle\Submission\AbstractHandleResponse;
+use Symfony\Component\Mime\Email;
 
 final class EmailHandleResponse extends AbstractHandleResponse
 {
-    /** @var \Swift_Message */
-    private $message;
+    private Email $message;
 
-    public function __construct(\Swift_Message $message)
+    public function __construct(Email $message)
     {
         $this->message = $message;
 
         parent::__construct(self::STATUS_SUCCESS, 'Submission send by mail.');
     }
 
-    public function getMessage(): \Swift_Message
+    public function getMessage(): Email
     {
         return $this->message;
     }

--- a/tests/Command/DatabaseStatsCommandTest.php
+++ b/tests/Command/DatabaseStatsCommandTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\SubmissionBundle\Tests\Command;
+
+use EMS\SubmissionBundle\Dto\FormSubmissionsCountDto;
+use EMS\SubmissionBundle\Repository\FormSubmissionRepository;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Mailer\EventListener\MessageLoggerListener;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+
+final class DatabaseStatsCommandTest extends KernelTestCase
+{
+    private MockObject $repository;
+    private Application $application;
+    private MessageLoggerListener $messageLogger;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = $this->createMock(FormSubmissionRepository::class);
+
+        $kernel = self::bootKernel();
+        $kernel->getContainer()->set('emss.repository.form_submission', $this->repository);
+
+        $this->application = new Application($kernel);
+
+        /** @var MessageLoggerListener $messageLogger */
+        $messageLogger = $kernel->getContainer()->get('functional_test.message_listener');
+        $this->messageLogger = $messageLogger;
+    }
+
+    public function testExecute()
+    {
+        $countDto = new FormSubmissionsCountDto('+1 month');
+        $countDto->setWaiting(1);
+        $countDto->setFailed(2);
+        $countDto->setProcessed(3);
+        $countDto->setTotal(6);
+
+        $this->repository->expects($this->any())->method('getCounts')->willReturn($countDto);
+
+        $command = $this->application->find('emss:database:stats');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'formName' => 'test',
+            '--instance' => 'test',
+            '--period' => '+1 month',
+            '--email-to' => 'test@test.be',
+        ]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString((string) $countDto->waiting, $output);
+        $this->assertStringContainsString((string) $countDto->failed, $output);
+        $this->assertStringContainsString((string) $countDto->processed, $output);
+        $this->assertStringContainsString((string) $countDto->total, $output);
+        $this->assertStringContainsString('Send stats email to: test@test.be', $output);
+
+        /** @var Email $email */
+        $email = $this->messageLogger->getEvents()->getMessages()[0];
+
+        $this->assertEquals(['test@test.be'], \array_map(fn (Address $a) => $a->toString(), $email->getTo()));
+        $this->assertEquals(['"elasticms form submissions" <noreply@elasticms.eu>'], \array_map(fn (Address $a) => $a->toString(), $email->getFrom()));
+        $this->assertEquals('submission stats', $email->getSubject());
+
+        $body = $email->getBody()->bodyToString();
+        $this->assertStringContainsString((string) $countDto->waiting, $body);
+        $this->assertStringContainsString((string) $countDto->failed, $body);
+        $this->assertStringContainsString((string) $countDto->processed, $body);
+        $this->assertStringContainsString((string) $countDto->total, $body);
+    }
+}

--- a/tests/Functional/App/Kernel.php
+++ b/tests/Functional/App/Kernel.php
@@ -8,7 +8,6 @@ use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use EMS\CommonBundle\EMSCommonBundle;
 use EMS\SubmissionBundle\EMSSubmissionBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
-use Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
@@ -34,7 +33,6 @@ final class Kernel extends BaseKernel
     {
         return [
             new EMSSubmissionBundle(),
-            new SwiftmailerBundle(),
             new FrameworkBundle(),
             new TwigBundle(),
             new EMSCommonBundle(),

--- a/tests/Functional/App/config/config.yml
+++ b/tests/Functional/App/config/config.yml
@@ -4,15 +4,16 @@ ems_submission:
     - { connection: "service-now-instance-a", user: "userA", password: "passB"}
     - { connection: "http-conn", user: "userTest", password: "testPass"}
 
-swiftmailer:
-  disable_delivery: true
-
 framework:
   session:
     handler_id: ~
+  mailer:
+    dsn: 'null://null'
   router:
     resource: 'routes.yml'
     strict_requirements: ~
+  profiler:
+    enabled: true
 
 twig:
   debug: true
@@ -20,8 +21,10 @@ twig:
   exception_controller: null
 
 services:
-  EMS\SubmissionBundle\Tests\Functional\App\ResponseFactory:
+  _defaults:
     public: true
+
+  EMS\SubmissionBundle\Tests\Functional\App\ResponseFactory:
   EMS\SubmissionBundle\Tests\Functional\App\HttpClient:
     arguments: ['@EMS\SubmissionBundle\Tests\Functional\App\ResponseFactory']
   Symfony\Contracts\HttpClient\HttpClientInterface:
@@ -29,25 +32,25 @@ services:
 
   #override filesystem (nullAdapter)
   emss.filesystem.factory:
-    public: true
     class: 'EMS\SubmissionBundle\Tests\Functional\App\FilesystemFactory'
+
+  emss.repository.form_submission:
+    class: EMS\SubmissionBundle\Repository\FormSubmissionRepository
+    arguments: [ '@doctrine' ]
+
+  functional_test.message_listener:
+    alias: mailer.logger_message_listener
 
   # alias the service so we can access it in the tests
   functional_test.emss.handler.email:
-    public: true
     alias: emss.handler.email
   functional_test.emss.handler.http:
-    public: true
     alias: emss.handler.http
   functional_test.emss.handler.pdf:
-    public: true
     alias: emss.handler.pdf
   functional_test.emss.handler.service_now:
-    public: true
     alias: emss.handler.service_now
   functional_test.emss.handler.sftp:
-    public: true
     alias: emss.handler.sftp
   functional_test.emss.handler.zip:
-    public: true
     alias: emss.handler.zip

--- a/tests/Functional/Handler/AbstractHandlerTest.php
+++ b/tests/Functional/Handler/AbstractHandlerTest.php
@@ -22,10 +22,8 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 abstract class AbstractHandlerTest extends AbstractFunctionalTest
 {
-    /** @var FormFactoryInterface */
-    protected $formFactory;
-    /** @var FormConfig */
-    protected $formConfig;
+    protected FormFactoryInterface $formFactory;
+    protected FormConfig $formConfig;
 
     protected function setUp(): void
     {

--- a/tests/Functional/Handler/PdfHandlerTest.php
+++ b/tests/Functional/Handler/PdfHandlerTest.php
@@ -84,11 +84,10 @@ final class PdfHandlerTest extends AbstractHandlerTest
         $emailHandleRequest = new HandleRequest($form, $this->formConfig, $responseCollector, $emailSubmission);
         /** @var EmailHandleResponse $emailResponse */
         $emailResponse = $emailHandler->handle($emailHandleRequest);
-        /** @var \Swift_Attachment[] $attachments */
-        $attachments = $emailResponse->getMessage()->getChildren();
+        $attachments = $emailResponse->getMessage()->getAttachments();
 
         $this->assertEquals('{"status":"success","data":"Submission send by mail."}', $emailResponse->getResponse());
-        $this->assertEquals('test.pdf', $attachments[0]->getFilename());
+        $this->assertEquals('application/pdf disposition: attachment filename: test.pdf', $attachments[0]->asDebugString());
         $this->assertEquals($pdfResponse->getContentRaw(), $attachments[0]->getBody());
     }
 }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |n|	
|BC breaks?     |y|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

BC break: we are now sending a Email object, we should check chained form submission. And test sending emails with the submission bundle

- Refactor mail sending with sf mailer and tests
- Added test for the DatabaseStatsCommand.php
- removed final_class => true